### PR TITLE
Fix top page images

### DIFF
--- a/src/javascripts/components/atoms/toppage-logo.tsx
+++ b/src/javascripts/components/atoms/toppage-logo.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-const ImgLogo = `/images/planets/star_1.png`;
+const ImgLogo = `/images/index/logo.png`;
 
 const TopPageLogo = () => (
   <div className="logo-container">

--- a/src/javascripts/components/atoms/toppage-planet-img.tsx
+++ b/src/javascripts/components/atoms/toppage-planet-img.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-const ImgPlanet = `${process.env.PUBLIC_URL}/images/index/top_earth.png`;
+const ImgPlanet = "/images/index/top_earth.png";
 
 const TopPagePlanet = () => (
   <div className="planet-img-container">


### PR DESCRIPTION
## 関連Issue :link:


## 要件概要 :green_book:
トップページの画像が壊れていたので直しました


## 詳細 :art:
### before 
<img width="1440" alt="スクリーンショット 2019-11-01 19 52 57" src="https://user-images.githubusercontent.com/39128496/68082837-fe692880-fe64-11e9-8818-80ca92124e11.png">

### after
<img width="1440" alt="スクリーンショット 2019-11-03 18 08 56" src="https://user-images.githubusercontent.com/39128496/68082840-0759fa00-fe65-11e9-9cb8-bca16ee4b9aa.png">


